### PR TITLE
add: 음악 커뮤니티 목록 조회 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,6 @@ repositories {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-batch")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-    implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")
@@ -35,7 +34,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("com.linecorp.kotlin-jdsl:spring-data-kotlin-jdsl-starter:2.2.1.RELEASE")
-    runtimeOnly("com.h2database:h2")
+    implementation("mysql:mysql-connector-java:8.0.32")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/Mz2moServerApplication.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/Mz2moServerApplication.kt
@@ -3,10 +3,10 @@ package com.emo_hip_hop.mz2mo
 import com.emo_hip_hop.mz2mo.music.adapter.output.persistence.CustomMusicCommunityRepositoryImpl
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
-import org.springframework.data.mongodb.repository.config.EnableMongoRepositories
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 
 @SpringBootApplication
-@EnableMongoRepositories(basePackageClasses = [
+@EnableJpaRepositories(basePackageClasses = [
     CustomMusicCommunityRepositoryImpl::class
 ])
 class Mz2moServerApplication

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/Mz2moServerApplication.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/Mz2moServerApplication.kt
@@ -1,9 +1,14 @@
 package com.emo_hip_hop.mz2mo
 
+import com.emo_hip_hop.mz2mo.music.adapter.output.persistence.CustomMusicCommunityRepositoryImpl
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories
 
 @SpringBootApplication
+@EnableMongoRepositories(basePackageClasses = [
+    CustomMusicCommunityRepositoryImpl::class
+])
 class Mz2moServerApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/global/common/domain/Pageable.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/global/common/domain/Pageable.kt
@@ -1,0 +1,17 @@
+package com.emo_hip_hop.mz2mo.global.common.domain
+
+class Pageable private constructor (
+    val lastIndexId: String,
+    val size: Int
+) {
+    companion object {
+        private const val DEFAULT_SIZE = 10
+        private const val DEFAULT_LAST_INDEX_ID: String = ""
+        fun of(lastIndexId: String, size: Int): Pageable {
+            if (size < 0) throw IllegalArgumentException("size must be greater than 0")
+            return Pageable(lastIndexId, size)
+        }
+        fun of(lastIndexId: String): Pageable = of(lastIndexId, DEFAULT_SIZE)
+        fun of(): Pageable = Pageable(DEFAULT_LAST_INDEX_ID, DEFAULT_SIZE)
+    }
+}

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/MusicCommunitiesResponse.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/MusicCommunitiesResponse.kt
@@ -1,0 +1,11 @@
+package com.emo_hip_hop.mz2mo.music.adapter.input.web
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(name = "MusicCommunitiesResponse", description = "음악 커뮤니티 목록 응답")
+data class MusicCommunitiesResponse(
+    @Schema(description = "목록 사이즈")
+    val musicCommunities: Int,
+    @Schema(description = "음악 커뮤니티 목록")
+    val list: List<MusicCommunityResponse>
+)

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/MusicCommunityController.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/MusicCommunityController.kt
@@ -1,9 +1,8 @@
 package com.emo_hip_hop.mz2mo.music.adapter.input.web
 
 import com.emo_hip_hop.mz2mo.global.WebAdapter
-import com.emo_hip_hop.mz2mo.music.application.port.input.AddMusicCommunityCommand
-import com.emo_hip_hop.mz2mo.music.application.port.input.AddMusicCommunityUseCase
-import com.emo_hip_hop.mz2mo.music.application.port.input.QueryMusicCommunityUseCase
+import com.emo_hip_hop.mz2mo.global.common.domain.Pageable
+import com.emo_hip_hop.mz2mo.music.application.port.input.*
 import com.emo_hip_hop.mz2mo.music.domain.MusicId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -22,7 +21,8 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/api/v1/musics/communities")
 class MusicCommunityController(
     private val addMusicCommunityUseCase: AddMusicCommunityUseCase,
-    private val queryMusicCommunityUseCase: QueryMusicCommunityUseCase
+    private val queryMusicCommunityUseCase: QueryMusicCommunityUseCase,
+    private val searchMusicCommunityUseCase: SearchMusicCommunityUseCase
 ) {
     @PostMapping
     @Operation(summary = "음악 커뮤니티 추가", description = "음악 커뮤니티를 추가합니다.")
@@ -52,6 +52,27 @@ class MusicCommunityController(
     fun queryMusicCommunityByMusicId(@PathVariable("musicId") rawMusicId: String): ResponseEntity<MusicCommunityResponse> {
         val musicId = MusicId(rawMusicId)
         val domain = queryMusicCommunityUseCase(musicId)
+        val response = domain.toResponse()
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/")
+    @Operation(summary = "음악 커뮤니티 검색", description = "음악 커뮤니티를 검색합니다. 검색 결과 목록을 반환합니다.")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "음악 커뮤니티 검색 성공",
+            content = [Content(schema = Schema(implementation = MusicCommunityResponse::class))]),
+        ApiResponse(responseCode = "400", description = "요청값이 올바르지 않을 경우",
+            content = [Content(schema = Schema(implementation = String::class))]),
+        ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했을 경우",
+            content = [Content(schema = Schema(implementation = String::class))]),
+    ])
+    fun searchMusicCommunity(
+        @RequestParam lastIndexId: String,
+        @RequestParam pageSize: Int
+    ): ResponseEntity<MusicCommunitiesResponse> {
+        val pageable = Pageable.of(lastIndexId, pageSize)
+        val query = SearchMusicCommunityQuery(pageable)
+        val domain = searchMusicCommunityUseCase(query)
         val response = domain.toResponse()
         return ResponseEntity.ok(response)
     }

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/MusicCommunityController.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/MusicCommunityController.kt
@@ -56,7 +56,7 @@ class MusicCommunityController(
         return ResponseEntity.ok(response)
     }
 
-    @GetMapping("/")
+    @GetMapping("/search")
     @Operation(summary = "음악 커뮤니티 검색", description = "음악 커뮤니티를 검색합니다. 검색 결과 목록을 반환합니다.")
     @ApiResponses(value = [
         ApiResponse(responseCode = "200", description = "음악 커뮤니티 검색 성공",

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/MusicCommunityMapper.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/MusicCommunityMapper.kt
@@ -11,6 +11,13 @@ fun MusicCommunity.toResponse(): MusicCommunityResponse {
     )
 }
 
+fun List<MusicCommunity>.toResponse(): MusicCommunitiesResponse {
+    return MusicCommunitiesResponse(
+        musicCommunities = size,
+        list = map { it.toResponse() }
+    )
+}
+
 private fun MusicVotes.toResponse(): List<MusicVoteResponse> = map { vote ->
     MusicVoteResponse(
         musicId = vote.musicId.id,

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/CustomMusicCommunityRepository.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/CustomMusicCommunityRepository.kt
@@ -1,0 +1,7 @@
+package com.emo_hip_hop.mz2mo.music.adapter.output.persistence
+
+import com.emo_hip_hop.mz2mo.global.common.domain.Pageable
+
+interface CustomMusicCommunityRepository {
+    fun search(pageable: Pageable): List<MusicCommunitiesJpaEntity>
+}

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/CustomMusicCommunityRepositoryImpl.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/CustomMusicCommunityRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package com.emo_hip_hop.mz2mo.music.adapter.output.persistence
+
+import com.emo_hip_hop.mz2mo.global.common.domain.Pageable
+import com.linecorp.kotlinjdsl.querydsl.expression.column
+import com.linecorp.kotlinjdsl.spring.data.SpringDataQueryFactory
+import com.linecorp.kotlinjdsl.spring.data.listQuery
+import org.springframework.stereotype.Component
+
+@Component
+class CustomMusicCommunityRepositoryImpl(
+    private val queryFactory: SpringDataQueryFactory
+): CustomMusicCommunityRepository {
+    override fun search(pageable: Pageable): List<MusicCommunitiesJpaEntity> {
+        return queryFactory.listQuery {
+            select(entity(MusicCommunitiesJpaEntity::class))
+            from(entity(MusicCommunitiesJpaEntity::class))
+            where(column(MusicCommunitiesJpaEntity::musicId).greaterThan(pageable.lastIndexId))
+            orderBy(column(MusicCommunitiesJpaEntity::musicId).asc())
+            limit(pageable.size)
+        }
+    }
+}

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicCommunitiesJpaEntity.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicCommunitiesJpaEntity.kt
@@ -1,12 +1,12 @@
 package com.emo_hip_hop.mz2mo.music.adapter.output.persistence
 
-import org.bson.types.ObjectId
-import org.springframework.data.annotation.Id
-import org.springframework.data.mongodb.core.mapping.Document
+import javax.persistence.*
 
-@Document(collection = "music_communities")
+@Entity
+@Table(name = "music_communities", indexes = [Index(name = "idx_id", columnList = "id")])
 class MusicCommunitiesJpaEntity(
     @Id
-    var id: ObjectId?,
+    @Column(columnDefinition = "VARCHAR(36)")
+    var id: String?,
     val musicId: String
 )

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicCommunityMapper.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicCommunityMapper.kt
@@ -3,11 +3,11 @@ package com.emo_hip_hop.mz2mo.music.adapter.output.persistence
 import com.emo_hip_hop.mz2mo.account.domain.AccountId
 import com.emo_hip_hop.mz2mo.emoji.domain.EmojiId
 import com.emo_hip_hop.mz2mo.music.domain.*
-import org.bson.types.ObjectId
+import java.util.*
 
 fun MusicCommunity.toEntity(): MusicCommunitiesJpaEntity {
     return MusicCommunitiesJpaEntity(
-        id = uuid?.let { ObjectId(it) },
+        id = uuid,
         musicId = music.id.let { if(it.isPresent) it.get().id else ""  }
     )
 }

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicCommunityPersistenceAdapter.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicCommunityPersistenceAdapter.kt
@@ -1,18 +1,20 @@
 package com.emo_hip_hop.mz2mo.music.adapter.output.persistence
 
 import com.emo_hip_hop.mz2mo.global.PersistenceAdapter
+import com.emo_hip_hop.mz2mo.global.common.domain.Pageable
 import com.emo_hip_hop.mz2mo.music.application.port.output.CreateMusicCommunityPort
 import com.emo_hip_hop.mz2mo.music.application.port.output.QueryMusicCommunityPort
+import com.emo_hip_hop.mz2mo.music.application.port.output.SearchMusicCommunityPort
 import com.emo_hip_hop.mz2mo.music.domain.MusicCommunity
 import com.emo_hip_hop.mz2mo.music.domain.MusicId
 import com.emo_hip_hop.mz2mo.music.domain.MusicOutOfSyncException
 
 @PersistenceAdapter
 class MusicCommunityPersistenceAdapter(
-    private val musicCommunityRepository: SpringDataMusicCommunityRepository,
+    private val musicCommunityRepository: SpringDataCustomMusicCommunityRepository,
     private val musicVoteRepository: SpringDataMusicVoteRepository,
     private val musicRepository: SpringDataMusicRepository
-): CreateMusicCommunityPort, QueryMusicCommunityPort {
+): CreateMusicCommunityPort, QueryMusicCommunityPort, SearchMusicCommunityPort {
     override fun create(domain: MusicCommunity): MusicCommunity {
         val entityToAdd = domain.toEntity()
         val musicCommunity = musicCommunityRepository.save(entityToAdd)
@@ -33,5 +35,10 @@ class MusicCommunityPersistenceAdapter(
             .orElseThrow{ MusicOutOfSyncException("id", musicId, syncTo = "musicCommunity") }
 
         return musicCommunity.toDomain(votes, music)
+    }
+
+    override fun search(pageable: Pageable): List<MusicCommunity> {
+        val musicCommunities = musicCommunityRepository.search(pageable)
+        return musicCommunities.map { aggregateMusicCommunity(it) }
     }
 }

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicCommunityPersistenceAdapter.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicCommunityPersistenceAdapter.kt
@@ -8,6 +8,7 @@ import com.emo_hip_hop.mz2mo.music.application.port.output.SearchMusicCommunityP
 import com.emo_hip_hop.mz2mo.music.domain.MusicCommunity
 import com.emo_hip_hop.mz2mo.music.domain.MusicId
 import com.emo_hip_hop.mz2mo.music.domain.MusicOutOfSyncException
+import java.util.*
 
 @PersistenceAdapter
 class MusicCommunityPersistenceAdapter(
@@ -16,7 +17,10 @@ class MusicCommunityPersistenceAdapter(
     private val musicRepository: SpringDataMusicRepository
 ): CreateMusicCommunityPort, QueryMusicCommunityPort, SearchMusicCommunityPort {
     override fun create(domain: MusicCommunity): MusicCommunity {
+        val id = UUID.randomUUID()
         val entityToAdd = domain.toEntity()
+        if(entityToAdd.id == null) entityToAdd.id = id.toString()
+        println("uuid is ${entityToAdd.id}")
         val musicCommunity = musicCommunityRepository.save(entityToAdd)
         return aggregateMusicCommunity(musicCommunity)
     }

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicJpaEntity.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicJpaEntity.kt
@@ -1,12 +1,12 @@
 package com.emo_hip_hop.mz2mo.music.adapter.output.persistence
 
-import org.bson.types.ObjectId
-import org.springframework.data.annotation.Id
-import org.springframework.data.mongodb.core.mapping.Document
+import javax.persistence.*
 
-@Document(collection = "music")
+@Entity
+@Table(name = "musics", indexes = [Index(name = "idx_id", columnList = "id")])
 class MusicJpaEntity(
     @Id
-    var id: ObjectId?,
+    @Column(columnDefinition = "VARCHAR(36)")
+    var id: String?,
     val youtubeId: String
 )

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicMapper.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicMapper.kt
@@ -2,11 +2,11 @@ package com.emo_hip_hop.mz2mo.music.adapter.output.persistence
 
 import com.emo_hip_hop.mz2mo.music.domain.Music
 import com.emo_hip_hop.mz2mo.music.domain.MusicId
-import org.bson.types.ObjectId
+import java.util.*
 
 fun Music.toEntity(): MusicJpaEntity =
     MusicJpaEntity(
-        id = id.orElse(null)?.let{ObjectId(it.id)},
+        id = id.orElse(null)?.id,
         youtubeId = youtubeId,
     )
 

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicPersistenceAdapter.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicPersistenceAdapter.kt
@@ -4,14 +4,18 @@ import com.emo_hip_hop.mz2mo.global.PersistenceAdapter
 import com.emo_hip_hop.mz2mo.music.application.port.output.CreateMusicPort
 import com.emo_hip_hop.mz2mo.music.application.port.output.ExistsMusicPort
 import com.emo_hip_hop.mz2mo.music.domain.Music
+import java.util.*
 
 @PersistenceAdapter
 class MusicPersistenceAdapter(
     private val musicRepository: SpringDataMusicRepository,
 ): CreateMusicPort, ExistsMusicPort {
     override fun create(music: Music): Music {
-        val entity = music.toEntity()
-        val savedEntity = musicRepository.save(entity)
+        val id = UUID.randomUUID()
+        val entityToAdd = music.toEntity()
+        if(entityToAdd.id == null) entityToAdd.id = id.toString()
+        println("uuid is ${entityToAdd.id}")
+        val savedEntity = musicRepository.save(entityToAdd)
         return savedEntity.toDomain()
     }
 

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicVoteJpaEntity.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicVoteJpaEntity.kt
@@ -1,13 +1,13 @@
 package com.emo_hip_hop.mz2mo.music.adapter.output.persistence
 
-import org.bson.types.ObjectId
-import org.springframework.data.annotation.Id
-import org.springframework.data.mongodb.core.mapping.Document
+import javax.persistence.*
 
-@Document(collection = "music_votes")
+@Entity
+@Table(name = "music_votes", indexes = [Index(name = "idx_id", columnList = "id")])
 class MusicVoteJpaEntity(
     @Id
-    var id: ObjectId?,
+    @Column(columnDefinition = "VARCHAR(36)")
+    var id: String?,
     val musicId: String,
     val accountId: String,
     val emojiId: String

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/SpringDataCustomMusicCommunityRepository.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/SpringDataCustomMusicCommunityRepository.kt
@@ -2,6 +2,6 @@ package com.emo_hip_hop.mz2mo.music.adapter.output.persistence
 
 import org.springframework.data.mongodb.repository.MongoRepository
 
-interface SpringDataMusicCommunityRepository: MongoRepository<MusicCommunitiesJpaEntity, String> {
+interface SpringDataCustomMusicCommunityRepository: MongoRepository<MusicCommunitiesJpaEntity, String>, CustomMusicCommunityRepository {
     fun findByMusicId(musicId: String): MusicCommunitiesJpaEntity?
 }

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/SpringDataCustomMusicCommunityRepository.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/SpringDataCustomMusicCommunityRepository.kt
@@ -1,7 +1,7 @@
 package com.emo_hip_hop.mz2mo.music.adapter.output.persistence
 
-import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.data.jpa.repository.JpaRepository
 
-interface SpringDataCustomMusicCommunityRepository: MongoRepository<MusicCommunitiesJpaEntity, String>, CustomMusicCommunityRepository {
+interface SpringDataCustomMusicCommunityRepository: JpaRepository<MusicCommunitiesJpaEntity, String>, CustomMusicCommunityRepository {
     fun findByMusicId(musicId: String): MusicCommunitiesJpaEntity?
 }

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/SpringDataMusicRepository.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/SpringDataMusicRepository.kt
@@ -1,7 +1,7 @@
 package com.emo_hip_hop.mz2mo.music.adapter.output.persistence
 
-import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.data.jpa.repository.JpaRepository
 
-interface SpringDataMusicRepository: MongoRepository<MusicJpaEntity, String> {
+interface SpringDataMusicRepository: JpaRepository<MusicJpaEntity, String> {
     fun existsByYoutubeId(youtubeId: String): Boolean
 }

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/SpringDataMusicVoteRepository.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/SpringDataMusicVoteRepository.kt
@@ -1,7 +1,7 @@
 package com.emo_hip_hop.mz2mo.music.adapter.output.persistence
 
-import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.data.jpa.repository.JpaRepository
 
-interface SpringDataMusicVoteRepository: MongoRepository<MusicVoteJpaEntity, String> {
+interface SpringDataMusicVoteRepository: JpaRepository<MusicVoteJpaEntity, String> {
     fun findAllByMusicId(musicId: String): List<MusicVoteJpaEntity>
 }

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/application/port/input/SearchMusicCommunityQuery.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/application/port/input/SearchMusicCommunityQuery.kt
@@ -1,0 +1,11 @@
+package com.emo_hip_hop.mz2mo.music.application.port.input
+
+import com.emo_hip_hop.mz2mo.global.common.domain.Pageable
+import com.emo_hip_hop.mz2mo.global.validate.SelfValidating
+
+/*
+나중에 search, emoji, isTrending isRecommended 등의 필터를 추가할 수 있을 것 같다.
+ */
+class SearchMusicCommunityQuery(
+    val pageable: Pageable
+): SelfValidating<SearchMusicCommunityQuery>()

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/application/port/input/SearchMusicCommunityUseCase.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/application/port/input/SearchMusicCommunityUseCase.kt
@@ -3,5 +3,5 @@ package com.emo_hip_hop.mz2mo.music.application.port.input
 import com.emo_hip_hop.mz2mo.music.domain.MusicCommunity
 
 interface SearchMusicCommunityUseCase {
-    operator fun invoke(query: SearchMusicCommunityQuery): MusicCommunity
+    operator fun invoke(query: SearchMusicCommunityQuery): List<MusicCommunity>
 }

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/application/port/input/SearchMusicCommunityUseCase.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/application/port/input/SearchMusicCommunityUseCase.kt
@@ -1,0 +1,7 @@
+package com.emo_hip_hop.mz2mo.music.application.port.input
+
+import com.emo_hip_hop.mz2mo.music.domain.MusicCommunity
+
+interface SearchMusicCommunityUseCase {
+    operator fun invoke(query: SearchMusicCommunityQuery): MusicCommunity
+}

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/application/port/output/SearchMusicCommunityPort.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/application/port/output/SearchMusicCommunityPort.kt
@@ -1,0 +1,8 @@
+package com.emo_hip_hop.mz2mo.music.application.port.output
+
+import com.emo_hip_hop.mz2mo.global.common.domain.Pageable
+import com.emo_hip_hop.mz2mo.music.domain.MusicCommunity
+
+interface SearchMusicCommunityPort {
+    fun search(pageable: Pageable): List<MusicCommunity>
+}

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/application/service/SearchMusicCommunityService.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/application/service/SearchMusicCommunityService.kt
@@ -1,0 +1,16 @@
+package com.emo_hip_hop.mz2mo.music.application.service
+
+import com.emo_hip_hop.mz2mo.global.UseCase
+import com.emo_hip_hop.mz2mo.music.application.port.input.SearchMusicCommunityQuery
+import com.emo_hip_hop.mz2mo.music.application.port.input.SearchMusicCommunityUseCase
+import com.emo_hip_hop.mz2mo.music.application.port.output.SearchMusicCommunityPort
+import com.emo_hip_hop.mz2mo.music.domain.MusicCommunity
+
+@UseCase
+class SearchMusicCommunityService(
+    private val searchMusicCommunityPort: SearchMusicCommunityPort
+): SearchMusicCommunityUseCase {
+    override fun invoke(query: SearchMusicCommunityQuery): List<MusicCommunity> {
+        return searchMusicCommunityPort.search(query.pageable)
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,3 @@
+logging:
+  level:
+    org.springframework.data.mongodb.core.MongoTemplate: DEBUG

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,3 +1,8 @@
-logging:
-  level:
-    org.springframework.data.mongodb.core.MongoTemplate: DEBUG
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
 
 spring:
   datasource:
-    url: jdbc:mysql://${DATABASE_HOST}:${DATABASE_PORT}/mz2mo?useSSL=false&serverTimezone=Asia/Seoul
+    url: jdbc:mysql://${DATABASE_HOST}:${DATABASE_PORT}/mz2mo?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
     username: ${DATABASE_USERNAME}
     password: ${DATABASE_PASSWORD}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,14 +2,10 @@ server:
   port: ${SERVER_PORT:8080}
 
 spring:
-  data:
-    mongodb:
-      username: ${DATABASE_USERNAME}
-      password: ${DATABASE_PASSWORD}
-      host: ${DATABASE_HOST}
-      port: ${DATABASE_PORT}
-      authentication-database: admin
-      database: mz2mo
+  datasource:
+    url: jdbc:mysql://${DATABASE_HOST}:${DATABASE_PORT}/mz2mo?useSSL=false&serverTimezone=Asia/Seoul
+    username: ${DATABASE_USERNAME}
+    password: ${DATABASE_PASSWORD}
 
 logging:
   level:


### PR DESCRIPTION
## Issue Number
[MZ2-41](https://mz2mo.atlassian.net/browse/MZ2-41?atlOrigin=eyJpIjoiMjNmM2NhNjBlNTczNDk0NDllNzNhMWUyNjY0MzFmNDgiLCJwIjoiaiJ9)
## Epic
음악 커뮤니티 목록 검색기능과 이에대한 API를 구현하였습니다.
## Description
- 이에 필요한 Msuic도메인 내 컴포넌트와 범용 도메인인 Pageable 도메인을 작성하였습니다.
- Cursor based 방식으로 페이지네이션 로직을 구성하였습니다
- 또한 기존에 계획한 DB migration 로직으로 인한 소스코드 변경사항을 반영하였습니다 
자세한 내용은 #11 을 참고해주세요.
## Checklist

- [x] ~~Code Review 요청~~
- [x] PR 제목 commit convention에 맞는지 확인
- [x] Label 설정

[MZ2-41]: https://mz2mo.atlassian.net/browse/MZ2-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ