### PR TITLE
add: 온보딩용 음악 투표 API 추가

### DIFF
--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/OnboardingMusicVoteController.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/OnboardingMusicVoteController.kt
@@ -1,0 +1,62 @@
+package com.emo_hip_hop.mz2mo.music.adapter.input.web
+
+import com.emo_hip_hop.mz2mo.account.application.port.input.QueryLoginedAccountUseCase
+import com.emo_hip_hop.mz2mo.emoji.application.port.input.QueryEmojiUseCase
+import com.emo_hip_hop.mz2mo.global.WebAdapter
+import com.emo_hip_hop.mz2mo.music.adapter.input.web.request.AddMusicVoteRequest
+import com.emo_hip_hop.mz2mo.music.adapter.input.web.response.MusicCommunityResponse
+import com.emo_hip_hop.mz2mo.music.application.port.input.AddMusicVoteCommand
+import com.emo_hip_hop.mz2mo.music.application.port.input.AddMusicVoteUseCase
+import com.emo_hip_hop.mz2mo.music.domain.MusicId
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@WebAdapter
+@Tag(name = "Onboarding Music Votes", description = "온보딩 음악 투표 API")
+@RestController
+@RequestMapping("/api/v1/onboarding/music/votes")
+class OnboardingMusicVoteController(
+    private val addMusicVoteUseCase: AddMusicVoteUseCase,
+    private val queryLoginedAccountUseCase: QueryLoginedAccountUseCase,
+    private val queryEmojiUseCase: QueryEmojiUseCase,
+    @Value("\${mz2mo.onboarding.music.id}")
+    private val onboardingMusicId: String
+) {
+    @PostMapping
+    @Operation(summary = "온보딩 음악 투표 추가", description = "온보딩 음악 투표를 추가합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "201", description = "음악 투표 추가 성공",
+                content = [Content(schema = Schema(implementation = MusicCommunityResponse::class))]
+            ),
+            ApiResponse(
+                responseCode = "400", description = "요청값이 올바르지 않을 경우",
+                content = [Content(schema = Schema(implementation = String::class))]
+            ),
+            ApiResponse(
+                responseCode = "404", description = "관련 자원을 찾을 수 없을경우",
+                content = [Content(schema = Schema(implementation = String::class))]
+            )
+        ]
+    )
+    fun addMusicVote(
+        @RequestBody request: AddMusicVoteRequest
+    ): ResponseEntity<MusicCommunityResponse> {
+        val musicId = onboardingMusicId
+        val accountId = queryLoginedAccountUseCase().id
+        val emojiId = queryEmojiUseCase(request.rawEmoji).id
+        val command = AddMusicVoteCommand(MusicId(musicId), accountId, emojiId)
+        val domain = addMusicVoteUseCase(command)
+        val response = domain.toResponse()
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,3 +6,7 @@ spring:
       hibernate:
         show_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
+mz2mo:
+  onboarding:
+    music:
+      id: 667896fb-f147-4e68-8470-a2d3d61e6a24


### PR DESCRIPTION
## Issue Number
[MZ2-45](https://mz2mo.atlassian.net/browse/MZ2-45?atlOrigin=eyJpIjoiOGVkY2FjNGFkMDlmNGFjMGI4NGYxMWU1YmQzMzJlNWEiLCJwIjoiaiJ9)
## Epic
온보딩용 음악투표API를 추가하였습니다.
## Description
온보딩 음악을 서버단에서 동적으로 관리하기 위해, 추가 API를 작성하였습니다.
## Checklist

- [x] ~~Code Review 요청~~
- [x] PR 제목 commit convention에 맞는지 확인
- [x] Label 설정

[MZ2-45]: https://mz2mo.atlassian.net/browse/MZ2-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ