### PR TITLE
add: 온보딩음악 투표율 조회 API 추가

### DIFF
--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/MusicCommunityMapper.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/MusicCommunityMapper.kt
@@ -1,8 +1,6 @@
 package com.emo_hip_hop.mz2mo.music.adapter.input.web
 
-import com.emo_hip_hop.mz2mo.music.adapter.input.web.response.MusicCommunitiesResponse
-import com.emo_hip_hop.mz2mo.music.adapter.input.web.response.MusicCommunityResponse
-import com.emo_hip_hop.mz2mo.music.adapter.input.web.response.MusicVoteResponse
+import com.emo_hip_hop.mz2mo.music.adapter.input.web.response.*
 import com.emo_hip_hop.mz2mo.music.domain.*
 
 fun MusicCommunity.toResponse(): MusicCommunityResponse {
@@ -16,12 +14,24 @@ fun MusicCommunity.toResponse(): MusicCommunityResponse {
 
 fun List<MusicCommunity>.toResponse(): MusicCommunitiesResponse {
     return MusicCommunitiesResponse(
-        musicCommunities = size,
+        size = size,
         list = map { it.toResponse() }
     )
 }
 
-private fun MusicVotes.toResponse(): List<MusicVoteResponse> = map { vote ->
+fun MusicVotePercentages.toResponse(): MusicVotePercentagesResponse {
+    val list = map { vote -> vote.toResponse() }
+    return MusicVotePercentagesResponse(list.size, list)
+}
+
+private fun MusicVotePercentage.toResponse() =
+    MusicVotePercentageResponse(
+        musicId = musicId.id,
+        emojiId = emojiId.id,
+        percentage = percentage
+    )
+
+fun MusicVotes.toResponse(): List<MusicVoteResponse> = map { vote ->
     MusicVoteResponse(
         musicId = vote.musicId.id,
         accountId = vote.accountId.id,

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/MusicVoteController.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/MusicVoteController.kt
@@ -52,14 +52,15 @@ class MusicVoteController(
         ]
     )
     fun addMusicVote(
-        @PathVariable
+        @PathVariable("musicId")
         @Pattern(regexp = UUID_PATTERN, message = "음악 ID 형식이 올바르지 않습니다.")
-        musicId: String,
+        rawMusicId: String,
         @RequestBody request: AddMusicVoteRequest
     ): ResponseEntity<MusicCommunityResponse> {
+        val musicId = MusicId(rawMusicId)
         val accountId = queryLoginedAccountUseCase().id
         val emojiId = queryEmojiUseCase(request.rawEmoji).id
-        val command = AddMusicVoteCommand(MusicId(musicId), accountId, emojiId)
+        val command = AddMusicVoteCommand(musicId, accountId, emojiId)
         val domain = addMusicVoteUseCase(command)
         val response = domain.toResponse()
         return ResponseEntity.status(HttpStatus.CREATED).body(response)
@@ -84,14 +85,15 @@ class MusicVoteController(
         ]
     )
     fun removeMusicVote(
-        @PathVariable
+        @PathVariable("musicId")
         @Pattern(regexp = UUID_PATTERN, message = "음악 ID 형식이 올바르지 않습니다.")
-        musicId: String,
+        rawMusicId: String,
         @RequestBody request: RemoveMusicVoteRequest
     ): ResponseEntity<MusicCommunityResponse> {
+        val musicId = MusicId(rawMusicId)
         val accountId = queryLoginedAccountUseCase().id
         val emojiId = queryEmojiUseCase(request.rawEmoji).id
-        val command = RemoveMusicVoteCommand(MusicId(musicId), accountId, emojiId)
+        val command = RemoveMusicVoteCommand(musicId, accountId, emojiId)
         val domain = removeMusicVoteUseCase(command)
         val response = domain.toResponse()
         return ResponseEntity.ok(response)

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/OnboardingMusicCommunityController.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/OnboardingMusicCommunityController.kt
@@ -1,0 +1,56 @@
+package com.emo_hip_hop.mz2mo.music.adapter.input.web
+
+import com.emo_hip_hop.mz2mo.global.WebAdapter
+import com.emo_hip_hop.mz2mo.music.adapter.input.web.response.MusicCommunityResponse
+import com.emo_hip_hop.mz2mo.music.application.port.input.QueryMusicCommunityUseCase
+import com.emo_hip_hop.mz2mo.music.domain.MusicId
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@WebAdapter
+@Tag(name = "Onboarding Music Communities", description = "온보딩 음악 커뮤니티 API")
+@RestController
+@RequestMapping("/api/v1/onboarding/music/community")
+class OnboardingMusicCommunityController(
+    private val queryMusicCommunityUseCase: QueryMusicCommunityUseCase,
+    @Value("\${mz2mo.onboarding.music.id}")
+    private val onboardingMusicId: String
+) {
+    @GetMapping
+    @Operation(summary = "온보딩 음악 커뮤니티 조회", description = "온보딩 음악 커뮤니티를 조회합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200", description = "음악 커뮤니티 조회 성공",
+                content = [Content(schema = Schema(implementation = MusicCommunityResponse::class))]
+            ),
+            ApiResponse(
+                responseCode = "400", description = "요청값이 올바르지 않을 경우",
+                content = [Content(schema = Schema(implementation = String::class))]
+            ),
+            ApiResponse(
+                responseCode = "404", description = "관련 자원을 찾을 수 없을경우",
+                content = [Content(schema = Schema(implementation = String::class))]
+            ),
+            ApiResponse(
+                responseCode = "500", description = "서버 내부 오류가 발생했을 경우",
+                content = [Content(schema = Schema(implementation = String::class))]
+            ),
+        ]
+    )
+    fun queryMusicCommunityByMusicId(): ResponseEntity<MusicCommunityResponse> {
+        val musicId = MusicId(onboardingMusicId)
+        val domain = queryMusicCommunityUseCase(musicId)
+        val response = domain.toResponse()
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/OnboardingMusicVoteController.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/OnboardingMusicVoteController.kt
@@ -5,8 +5,10 @@ import com.emo_hip_hop.mz2mo.emoji.application.port.input.QueryEmojiUseCase
 import com.emo_hip_hop.mz2mo.global.WebAdapter
 import com.emo_hip_hop.mz2mo.music.adapter.input.web.request.AddMusicVoteRequest
 import com.emo_hip_hop.mz2mo.music.adapter.input.web.response.MusicCommunityResponse
+import com.emo_hip_hop.mz2mo.music.adapter.input.web.response.MusicVotePercentagesResponse
 import com.emo_hip_hop.mz2mo.music.application.port.input.AddMusicVoteCommand
 import com.emo_hip_hop.mz2mo.music.application.port.input.AddMusicVoteUseCase
+import com.emo_hip_hop.mz2mo.music.application.port.input.QueryMusicVotePercentageByEmojiUseCase
 import com.emo_hip_hop.mz2mo.music.domain.MusicId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -25,11 +27,33 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/api/v1/onboarding/music/votes")
 class OnboardingMusicVoteController(
     private val addMusicVoteUseCase: AddMusicVoteUseCase,
+    private val queryMusicVotePercentageUseCase: QueryMusicVotePercentageByEmojiUseCase,
     private val queryLoginedAccountUseCase: QueryLoginedAccountUseCase,
     private val queryEmojiUseCase: QueryEmojiUseCase,
     @Value("\${mz2mo.onboarding.music.id}")
     private val onboardingMusicId: String
 ) {
+    @GetMapping
+    @Operation(summary = "온보딩 음악 투표율 조회", description = "온보딩 음악 투표율을 조회합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200", description = "음악 투표율 조회 성공",
+                content = [Content(schema = Schema(implementation = MusicCommunityResponse::class))]
+            ),
+            ApiResponse(
+                responseCode = "404", description = "관련 자원을 찾을 수 없을경우",
+                content = [Content(schema = Schema(implementation = String::class))]
+            )
+        ]
+    )
+    fun queryMusicVotePercentage(): ResponseEntity<MusicVotePercentagesResponse> {
+        val musicId = MusicId(onboardingMusicId)
+        val domain = queryMusicVotePercentageUseCase(musicId)
+        val response = domain.toResponse()
+        return ResponseEntity.ok(response)
+    }
+
     @PostMapping
     @Operation(summary = "온보딩 음악 투표 추가", description = "온보딩 음악 투표를 추가합니다.")
     @ApiResponses(

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/OnboardingMusicVoteController.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/OnboardingMusicVoteController.kt
@@ -51,10 +51,10 @@ class OnboardingMusicVoteController(
     fun addMusicVote(
         @RequestBody request: AddMusicVoteRequest
     ): ResponseEntity<MusicCommunityResponse> {
-        val musicId = onboardingMusicId
+        val musicId = MusicId(onboardingMusicId)
         val accountId = queryLoginedAccountUseCase().id
         val emojiId = queryEmojiUseCase(request.rawEmoji).id
-        val command = AddMusicVoteCommand(MusicId(musicId), accountId, emojiId)
+        val command = AddMusicVoteCommand(musicId, accountId, emojiId)
         val domain = addMusicVoteUseCase(command)
         val response = domain.toResponse()
         return ResponseEntity.status(HttpStatus.CREATED).body(response)

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/response/MusicCommunitiesResponse.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/response/MusicCommunitiesResponse.kt
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 @Schema(name = "MusicCommunitiesResponse", description = "음악 커뮤니티 목록 응답")
 data class MusicCommunitiesResponse(
     @Schema(description = "목록 사이즈")
-    val musicCommunities: Int,
+    val size: Int,
     @Schema(description = "음악 커뮤니티 목록")
     val list: List<MusicCommunityResponse>
 )

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/response/MusicVotePercentageResponse.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/response/MusicVotePercentageResponse.kt
@@ -1,0 +1,18 @@
+package com.emo_hip_hop.mz2mo.music.adapter.input.web.response
+
+import com.emo_hip_hop.mz2mo.global.validate.domain.UUID_EXAMPLE
+import com.emo_hip_hop.mz2mo.global.validate.domain.UUID_PATTERN
+import io.swagger.v3.oas.annotations.media.Schema
+import javax.validation.constraints.Pattern
+
+@Schema(name = "MusicVotePercentageResponse", description = "음악 투표율 응답")
+data class MusicVotePercentageResponse(
+    @Schema(description = "음악 ID", example = UUID_EXAMPLE)
+    @Pattern(regexp = UUID_PATTERN, message = "음악 ID 형식이 올바르지 않습니다.")
+    val musicId: String,
+    @Schema(description = "이모지 ID", example = UUID_EXAMPLE)
+    @Pattern(regexp = UUID_PATTERN, message = "이모지 ID 형식이 올바르지 않습니다.")
+    val emojiId: String,
+    @Schema(description = "투표율", example = "28.53")
+    val percentage: Double,
+)

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/response/MusicVotePercentagesResponse.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/response/MusicVotePercentagesResponse.kt
@@ -1,0 +1,11 @@
+package com.emo_hip_hop.mz2mo.music.adapter.input.web.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(name = "MusicVotePercentagesResponse", description = "음악 투표율 목록 응답")
+data class MusicVotePercentagesResponse(
+    @Schema(description = "목록 사이즈")
+    val size: Int = 0,
+    @Schema(description = "음악 커뮤니티 목록")
+    val list: List<MusicVotePercentageResponse>
+)

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/response/MusicVoteResponse.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/input/web/response/MusicVoteResponse.kt
@@ -8,6 +8,7 @@ import javax.validation.constraints.Pattern
 @Schema(name = "MusicVoteResponse", description = "음악 투표 응답")
 data class MusicVoteResponse(
     @Schema(description = "음악 ID", example = UUID_EXAMPLE)
+    @Pattern(regexp = UUID_PATTERN, message = "음악 ID 형식이 올바르지 않습니다.")
     val musicId: String,
     @Schema(description = "계정 ID", example = UUID_EXAMPLE)
     @Pattern(regexp = UUID_PATTERN, message = "계정 ID 형식이 올바르지 않습니다.")

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicCommunityMapper.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicCommunityMapper.kt
@@ -22,9 +22,9 @@ fun MusicCommunitiesJpaEntity.toDomain(votes: List<MusicVoteJpaEntity>, music: M
     )
 }
 
-private fun MusicVoteJpaEntity.toDomain(): MusicVote {
+fun MusicVoteJpaEntity.toDomain(): MusicVote {
     return MusicVote(
-        uuid = id,
+        id = MusicVoteId(id),
         musicId = MusicId(musicId),
         accountId = AccountId(accountId),
         emojiId = EmojiId(emojiId)

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicCommunityPersistenceAdapter.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicCommunityPersistenceAdapter.kt
@@ -69,10 +69,10 @@ class MusicCommunityPersistenceAdapter(
         domains: MusicVotes
     ): List<MusicVoteJpaEntity> =
         domains.filter { domain -> entities.none { entity -> compareWithoutId(domain, entity) } }
-            .map { it.toEntity(musicId.id) }
+            .map { it.toEntity() }
 
     private fun compareWithoutId(domain: MusicVote, entity: MusicVoteJpaEntity): Boolean =
-        domain.emojiId.id == entity.emojiId && domain.musicId.id == entity.musicId
+        domain.emojiId.id == entity.emojiId && domain.musicId.id == entity.musicId && domain.accountId.id == entity.accountId
 
     override fun findByMusicId(id: MusicId): MusicCommunity? {
         val musicCommunity = musicCommunityRepository.findByMusicId(id.id) ?: return null

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicCommunityPersistenceAdapter.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicCommunityPersistenceAdapter.kt
@@ -79,7 +79,7 @@ class MusicCommunityPersistenceAdapter(
         return aggregateMusicCommunity(musicCommunity)
     }
 
-    fun aggregateMusicCommunity(
+    private fun aggregateMusicCommunity(
         musicCommunity: MusicCommunitiesJpaEntity,
     ): MusicCommunity {
         val musicId = musicCommunity.musicId

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicVoteMapper.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicVoteMapper.kt
@@ -3,9 +3,9 @@ package com.emo_hip_hop.mz2mo.music.adapter.output.persistence
 import com.emo_hip_hop.mz2mo.music.adapter.output.persistence.entity.MusicVoteJpaEntity
 import com.emo_hip_hop.mz2mo.music.domain.MusicVote
 
-fun MusicVote.toEntity(id: String): MusicVoteJpaEntity =
+fun MusicVote.toEntity(): MusicVoteJpaEntity =
     MusicVoteJpaEntity(
-        id = id,
+        id = id.id,
         musicId = musicId.id,
         accountId = accountId.id,
         emojiId = emojiId.id,

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicVotePersistenceAdapter.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/MusicVotePersistenceAdapter.kt
@@ -1,0 +1,19 @@
+package com.emo_hip_hop.mz2mo.music.adapter.output.persistence
+
+import com.emo_hip_hop.mz2mo.global.PersistenceAdapter
+import com.emo_hip_hop.mz2mo.music.adapter.output.persistence.entity.MusicVoteJpaEntity
+import com.emo_hip_hop.mz2mo.music.adapter.output.persistence.repository.SpringDataMusicVoteRepository
+import com.emo_hip_hop.mz2mo.music.application.port.output.QueryMusicVotePort
+import com.emo_hip_hop.mz2mo.music.domain.MusicId
+import com.emo_hip_hop.mz2mo.music.domain.MusicVotes
+
+@PersistenceAdapter
+class MusicVotePersistenceAdapter(
+    private val musicVoteRepository: SpringDataMusicVoteRepository,
+) : QueryMusicVotePort {
+    override fun invoke(musicId: MusicId): MusicVotes {
+        val votes = musicVoteRepository.findAllByMusicId(musicId.id)
+            .map(MusicVoteJpaEntity::toDomain)
+        return MusicVotes.of(votes)
+    }
+}

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/entity/MusicVoteJpaEntity.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/adapter/output/persistence/entity/MusicVoteJpaEntity.kt
@@ -7,7 +7,7 @@ import javax.persistence.*
 class MusicVoteJpaEntity(
     @Id
     @Column(columnDefinition = "VARCHAR(36)")
-    var id: String?,
+    var id: String,
     val musicId: String,
     val accountId: String,
     val emojiId: String

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/application/port/input/QueryMusicVotePercentageByEmojiUseCase.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/application/port/input/QueryMusicVotePercentageByEmojiUseCase.kt
@@ -1,0 +1,8 @@
+package com.emo_hip_hop.mz2mo.music.application.port.input
+
+import com.emo_hip_hop.mz2mo.music.domain.MusicId
+import com.emo_hip_hop.mz2mo.music.domain.MusicVotePercentages
+
+interface QueryMusicVotePercentageByEmojiUseCase {
+    operator fun invoke(musicId: MusicId): MusicVotePercentages
+}

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/application/port/output/QueryMusicVotePort.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/application/port/output/QueryMusicVotePort.kt
@@ -1,0 +1,8 @@
+package com.emo_hip_hop.mz2mo.music.application.port.output
+
+import com.emo_hip_hop.mz2mo.music.domain.MusicId
+import com.emo_hip_hop.mz2mo.music.domain.MusicVotes
+
+interface QueryMusicVotePort {
+    operator fun invoke(musicId: MusicId): MusicVotes
+}

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/application/service/AddMusicVoteService.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/application/service/AddMusicVoteService.kt
@@ -25,7 +25,7 @@ class AddMusicVoteService(
 
         checkCanVote(musicCommunity, command)
 
-        val vote = MusicVote(null, musicId, command.accountId, command.emojiId)
+        val vote = MusicVote(MusicVoteId.create(), musicId, command.accountId, command.emojiId)
         val musicCommunityToUpdate = musicCommunity.addVote(vote)
         return updateMusicCommunityPort.update(musicCommunityToUpdate)
     }
@@ -33,7 +33,7 @@ class AddMusicVoteService(
     private fun checkCanVote(musicCommunity: MusicCommunity, command: AddMusicVoteCommand) {
         val musicId = command.musicId
 
-        val currentVoteCount = musicCommunity.votes.size
+        val currentVoteCount = musicCommunity.votes.filter { it.accountId.id == command.accountId.id }.size
         if (currentVoteCount >= maxVoteCount) throw ExceedMaximumVotesPerUserException(musicId.id, currentVoteCount, maxVoteCount)
 
         val isAlreadyVote = musicCommunity.votes.any { it.accountId.id == command.accountId.id && it.emojiId.id == command.emojiId.id }

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/application/service/QueryMusicVotePercentageByEmojiService.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/application/service/QueryMusicVotePercentageByEmojiService.kt
@@ -1,0 +1,29 @@
+package com.emo_hip_hop.mz2mo.music.application.service
+
+import com.emo_hip_hop.mz2mo.music.application.port.input.QueryMusicVotePercentageByEmojiUseCase
+import com.emo_hip_hop.mz2mo.music.application.port.output.QueryMusicVotePort
+import com.emo_hip_hop.mz2mo.music.domain.MusicId
+import com.emo_hip_hop.mz2mo.music.domain.MusicVotePercentage
+import com.emo_hip_hop.mz2mo.music.domain.MusicVotePercentages
+import com.emo_hip_hop.mz2mo.music.domain.MusicVotes
+import org.springframework.stereotype.Service
+
+@Service
+class QueryMusicVotePercentageByEmojiService(
+    private val queryMusicVotesPort: QueryMusicVotePort,
+) : QueryMusicVotePercentageByEmojiUseCase {
+    override fun invoke(musicId: MusicId): MusicVotePercentages {
+        val votes = queryMusicVotesPort(musicId)
+        return aggregateVoteAndCalculatePercentageByEmoji(musicId, votes)
+    }
+
+    private fun aggregateVoteAndCalculatePercentageByEmoji(musicId: MusicId, votes: MusicVotes): MusicVotePercentages {
+        val totalVotes = votes.size
+        val aggregatedVotesByEmoji = votes.groupBy { it.emojiId }
+        val calculatedPercentageList = aggregatedVotesByEmoji.map { (emojiId, votes) ->
+            val percentage = votes.size.toDouble() / totalVotes * 100
+            return@map MusicVotePercentage(musicId, emojiId, percentage)
+        }
+        return MusicVotePercentages.of(calculatedPercentageList)
+    }
+}

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/domain/MusicVote.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/domain/MusicVote.kt
@@ -4,7 +4,7 @@ import com.emo_hip_hop.mz2mo.account.domain.AccountId
 import com.emo_hip_hop.mz2mo.emoji.domain.EmojiId
 
 data class MusicVote(
-    val uuid: String?,
+    val id: MusicVoteId,
     val musicId: MusicId,
     val accountId: AccountId,
     val emojiId: EmojiId

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/domain/MusicVoteId.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/domain/MusicVoteId.kt
@@ -1,0 +1,11 @@
+package com.emo_hip_hop.mz2mo.music.domain
+
+import java.util.*
+
+data class MusicVoteId(
+    val id: String
+) {
+    companion object {
+        fun create(): MusicVoteId = MusicVoteId(UUID.randomUUID().toString())
+    }
+}

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/domain/MusicVotePercentage.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/domain/MusicVotePercentage.kt
@@ -1,0 +1,9 @@
+package com.emo_hip_hop.mz2mo.music.domain
+
+import com.emo_hip_hop.mz2mo.emoji.domain.EmojiId
+
+data class MusicVotePercentage(
+    val musicId: MusicId,
+    val emojiId: EmojiId,
+    val percentage: Double
+)

--- a/src/main/kotlin/com/emo_hip_hop/mz2mo/music/domain/MusicVotePercentages.kt
+++ b/src/main/kotlin/com/emo_hip_hop/mz2mo/music/domain/MusicVotePercentages.kt
@@ -1,0 +1,8 @@
+package com.emo_hip_hop.mz2mo.music.domain
+
+class MusicVotePercentages private constructor(votes: List<MusicVotePercentage>) : List<MusicVotePercentage> by votes {
+    companion object {
+        fun empty() = MusicVotePercentages(emptyList())
+        fun of(votes: List<MusicVotePercentage>) = MusicVotePercentages(votes)
+    }
+}


### PR DESCRIPTION
## Issue Number
[MZ2-45](https://mz2mo.atlassian.net/browse/MZ2-45?atlOrigin=eyJpIjoiZTFmNzZkMTUzMTE0NDY5Yjg2ZWYyNDQ1NDc0NmJiZTgiLCJwIjoiaiJ9)
## Epic
온보딩 음악 투표에 대한 유저 투표율 조회 API를 작성하였습니다.
## Description
아래 API를 구현하였습니다.
```curl
curl -X 'GET' \
  'http://localhost:8080/api/v1/onboarding/music/votes' \
  -H 'accept: */*'
```
## Checklist

- [x] ~~Code Review 요청~~
- [x] PR 제목 commit convention에 맞는지 확인
- [x] Label 설정

[MZ2-45]: https://mz2mo.atlassian.net/browse/MZ2-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ